### PR TITLE
Store sstate-cache to use as a mirror

### DIFF
--- a/factories/openxt.py
+++ b/factories/openxt.py
@@ -108,6 +108,14 @@ def step_upload_upgrade(srcfmt, destfmt):
         masterdest=util.Interpolate(destpath + "/respository"),
         url=None)
 
+# Upload the sstate cache to the build-master.
+def step_upload_sstate(srcfmt, destfmt):
+    destpath = destfmt + "/%(prop:buildername)s/sstate"
+    return steps.DirectoryUpload(
+        workersrc=util.Interpolate(srcfmt + "/build-0/sstate-cache"),
+        masterdest=util.Interpolate(destpath),
+        url=None)
+
 # Layout of the codebases for the different repositories for bordel.
 codebase_layout = {
     'bats-suite': '/openxt/bats-suite',
@@ -275,7 +283,7 @@ def factory_custom_legacy_clean(workdir_base, deploy_base, codebases_oe):
 # "stable" will run a build using only the Openembedded resources.
 # No externalsrc involved and the recipes dictate what OE will fetch.
 # Only the download cache is re-used, each build start from a fresh sstate.
-def factory_stable(workdir_base, deploy_base, codebases_stable):
+def factory_stable(workdir_base, deploy_base, codebases_stable, deploy_sstate):
     workdir_fmt = workdir_base + "/%(prop:buildername)s-%(prop:buildnumber)s"
     f = util.BuildFactory()
     # Fetch sources.
@@ -299,5 +307,7 @@ def factory_stable(workdir_base, deploy_base, codebases_stable):
     f.addStep(step_bordel_deploy(util.Interpolate(workdir_fmt)))
     f.addStep(step_upload_installer(workdir_fmt, deploy_base))
     f.addStep(step_upload_upgrade(workdir_fmt, deploy_base))
+    if deploy_sstate:
+        f.addStep(step_upload_sstate(workdir_fmt, deploy_base))
     f.addStep(step_remove_history(workdir_base))
     return f

--- a/master.cfg
+++ b/master.cfg
@@ -140,7 +140,7 @@ c['schedulers'] = [
         "zeus", codebases_stable_zeus
     ),
     scheduler_nightly(
-        "nightly-stable-zeus", [ "zeus-stable" ],
+        "nightly-stable-zeus", [ "zeus-stable-sstate" ],
         "zeus", codebases_stable_zeus,
         1, 0
     ),
@@ -161,7 +161,7 @@ c['schedulers'] = [
         "master", codebases_stable_master
     ),
     scheduler_nightly(
-        "nightly-stable-master", [ "master-stable" ],
+        "nightly-stable-master", [ "master-stable-sstate" ],
         "master", codebases_stable_master,
         3, 0
     ),
@@ -243,7 +243,16 @@ c['builders'] = [
         workernames=workers_oe_zeus['names'],
         factory=factory_stable(
             workers_oe_zeus['workdir'], workers_oe_zeus['deploydir'],
-            codebases_stable_zeus),
+            codebases_stable_zeus, False),
+        locks=[ lock_workers.access('counting') ]
+    ),
+    util.BuilderConfig(
+        name="zeus-stable-sstate",
+        description="OpenXT/Zeus: Stable build.",
+        workernames=workers_oe_zeus['names'],
+        factory=factory_stable(
+            workers_oe_zeus['workdir'], workers_oe_zeus['deploydir'],
+            codebases_stable_zeus, True),
         locks=[ lock_workers.access('counting') ]
     ),
 
@@ -281,7 +290,16 @@ c['builders'] = [
         workernames=workers_oe_master['names'],
         factory=factory_stable(
             workers_oe_master['workdir'], workers_oe_master['deploydir'],
-            codebases_stable_master),
+            codebases_stable_master, False),
+        locks=[ lock_workers.access('counting') ]
+    ),
+    util.BuilderConfig(
+        name="master-stable-sstate",
+        description="OpenXT/Master: Stable build.",
+        workernames=workers_oe_master['names'],
+        factory=factory_stable(
+            workers_oe_master['workdir'], workers_oe_master['deploydir'],
+            codebases_stable_master, True),
         locks=[ lock_workers.access('counting') ]
     ),
 


### PR DESCRIPTION
Upload the sstate-cache to the build master so it can be used as a mirror to speed up Openxt builds.